### PR TITLE
Minor improvement and don't override customer's selected shipping method

### DIFF
--- a/app/code/community/IntegerNet/Autoshipping/Model/Observer.php
+++ b/app/code/community/IntegerNet/Autoshipping/Model/Observer.php
@@ -43,6 +43,9 @@ class IntegerNet_Autoshipping_Model_Observer
 
             $quote = $this->_getCheckoutSession()->getQuote();
             $shippingAddress = $quote->getShippingAddress();
+            if($shippingAddress->getShippingMethod()){
+                return $this; //don't override a method that was previously set
+            }
 
             $shippingAddress->setCountryId($country);
             $shippingAddress->setCollectShippingRates(true);


### PR DESCRIPTION
Two optimizations - firstly, don't check the block if the functionality is disabled in System>Config, and secondly, don't override the customer's selection
