### PR TITLE
Don't calculate shipping costs for empty cart

### DIFF
--- a/app/code/community/IntegerNet/Autoshipping/Model/Observer.php
+++ b/app/code/community/IntegerNet/Autoshipping/Model/Observer.php
@@ -25,6 +25,9 @@ class IntegerNet_Autoshipping_Model_Observer
             }
 
             $quote = $this->_getCheckoutSession()->getQuote();
+            if (0 == $quote->getItemsCount()) {
+                return;
+            }
 
             $billingAddress = $quote->getBillingAddress();
             if (!$billingAddress->getCountryId()) {


### PR DESCRIPTION
Using Magento 1.8.1 we sometimes ran into trouble, if the cart was empty. This patch stops calculation for empty carts.