### PR TITLE
Fixed module for Magento 1.9.2

### DIFF
--- a/app/code/community/IntegerNet/Autoshipping/etc/system.xml
+++ b/app/code/community/IntegerNet/Autoshipping/etc/system.xml
@@ -61,7 +61,7 @@
                         <ignore_shipping_methods translate="label">
                             <label>Ignore Shipping Methods</label>
                             <frontend_type>multiselect</frontend_type>
-                            <source_model>autoshipping/source_shippingMethods</source_model>
+                            <source_model>IntegerNet_Autoshipping_Model_Source_ShippingMethods</source_model>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>


### PR DESCRIPTION
The old source_model name did not work in Magento 1.9.2