### PR TITLE
Fixed country setting for shipping address

### DIFF
--- a/app/code/community/IntegerNet/Autoshipping/Model/Observer.php
+++ b/app/code/community/IntegerNet/Autoshipping/Model/Observer.php
@@ -40,8 +40,10 @@ class IntegerNet_Autoshipping_Model_Observer
         }
 
         $shippingAddress = $quote->getShippingAddress();
-        $shippingAddress->setCountryId($country);
-
+        if (!$shippingAddress->getCountryId()) {
+            $shippingAddress->setCountryId($country);
+        }
+        
         if (!$shippingAddress->getFreeMethodWeight()) {
             $shippingAddress->setFreeMethodWeight($shippingAddress->getWeight());
         }


### PR DESCRIPTION
This fixes the following use case:
- customer goes to checkout and enters an address with different country than the auto shipping country but does not purchase
- customer goes back to a product and checks out using the PayPalExpress button
- the address of the existing quote is taken and transferred to PayPal, but the country is changed to the auto shipping country
- if the customer does not check the address again, he checks out with a completely wrong country