### PR TITLE
Revert "Fixed country setting for shipping address"

### DIFF
--- a/app/code/community/IntegerNet/Autoshipping/Model/Observer.php
+++ b/app/code/community/IntegerNet/Autoshipping/Model/Observer.php
@@ -40,10 +40,8 @@ class IntegerNet_Autoshipping_Model_Observer
         }
 
         $shippingAddress = $quote->getShippingAddress();
-        if (!$shippingAddress->getCountryId()) {
-            $shippingAddress->setCountryId($country);
-        }
-        
+        $shippingAddress->setCountryId($country);
+
         if (!$shippingAddress->getFreeMethodWeight()) {
             $shippingAddress->setFreeMethodWeight($shippingAddress->getWeight());
         }


### PR DESCRIPTION
Reverts integer-net/Autoshipping#33

@schmengler , sorry, did not test properly. This fix fixes indeed my problem but destroys the general functionality of this module. 
Sorry for that, please revert. I will look for a better fix and open a new pull request then,